### PR TITLE
Simplify Kanata layout system

### DIFF
--- a/kanata/config.kbd
+++ b/kanata/config.kbd
@@ -40,74 +40,35 @@
 )
 
 ;; ===============================================
-;; MAIN LAYER - Colemak (default)
-;; ===============================================
-
-;; Colemak without home row mods
-(deflayer colemak
-  esc  f1   f2   f3   f4   f5   f6   f7   f8   f9   f10  f11  f12  del
-  grv  S-1  S-2  S-3  AG-4  S-5  S-6  S-7  S-8  S-9  S-0  +    ´    bspc
-  @tab-hyper q    w    f    p    g    j    l    u    y    ö    å    S-¨ ret
-  @caps-multi a    r    s    t    d    h    n    e    i    o    ä    '
-  @lsft-layer <    z    x    c    v    b    k    m    ,    .    -    @rsft-layer
-  lctl lmet lalt           @spc-mods                    @ralt-layer        rctl
-)
-
-;; ===============================================
-;; QWERTY LAYER
+;; MAIN LAYER - QWERTY (default)
 ;; ===============================================
 
 ;; QWERTY without home row mods
 (deflayer qwerty
   esc  f1   f2   f3   f4   f5   f6   f7   f8   f9   f10  f11  f12  del
-  grv  S-1  S-2  S-3  AG-4  S-5  S-6  S-7  S-8  S-9  S-0  +    ´    bspc
-  @tab-hyper q    w    e    r    t    y    u    i    o    p    å    S-¨ ret
-  @caps-multi a    s    d    f    g    h    j    k    l    ö    ä    '
-  @lsft-layer <    z    x    c    v    b    n    m    ,    .    -    @rsft-layer
-  lctl lmet lalt              @spc-mods                 @ralt-layer        rctl
+  grv  1    2    3    4    5    6    7    8    9    0    +    ´    bspc
+  @tab-multi q    w    e    r    t    y    u    i    o    p    å    ¨ ret
+  @caps-multi-qwerty a    s    d    f    g    h    j    k    l    ö    ä    '
+  lsft <    z    x    c    v    b    n    m    ,    .    -    rsft
+  lctl lmet lalt              @spc-mods                 ralt        rctl
 )
 
 ;; ===============================================
-;; VIM NAVIGATION LAYER
+;; COLEMAK LAYER
 ;; ===============================================
 
-;; Vim navigation on caps hold - using physical key positions
-(deflayer vim-nav
-  _    _    _    _    _    _    _    _    _    _    _    _    _    _
-  _    _    _    _    _    _    _    _    _    _    _    _    _    _
-  _    _    _    _    _    _    pgdn C-down C-up pgup _    _    _    _
-  _    _    _    _    _    _    left down up   rght _    _    _
-  _    _    _    C-S-x _    _    _    _    home end  _    _         _
-  _    _    _                       _                    _         _
+;; Colemak without home row mods
+(deflayer colemak
+  esc  f1   f2   f3   f4   f5   f6   f7   f8   f9   f10  f11  f12  del
+  grv  1    2    3    4    5    6    7    8    9    0    +    ´    bspc
+  @tab-multi q    w    f    p    g    j    l    u    y    ö    å    ¨ ret
+  @caps-multi-colemak a    r    s    t    d    h    n    e    i    o    ä    '
+  lsft <    z    x    c    v    b    k    m    ,    .    -    rsft
+  lctl lmet lalt           @spc-mods                    ralt        rctl
 )
 
-;; ===============================================
-;; NUMBER LAYER (AltGr-activated)
-;; ===============================================
 
-;; Number layer - activated by holding AltGr on number row
-(deflayer numbers
-  _    _    _    _    _    _    _    _    _    _    _    _    _    _
-  _    (multi (release-key ralt) 1) (multi (release-key ralt) 2) (multi (release-key ralt) 3) (multi (release-key ralt) 4) (multi (release-key ralt) 5) (multi (release-key ralt) 6) (multi (release-key ralt) 7) (multi (release-key ralt) 8) (multi (release-key ralt) 9) (multi (release-key ralt) 0) _    _    _
-  _    _    _    _    _    _    _    _    _    _    _    _    (multi (release-key ralt) ¨)    _
-  _    _    _    _    _    _    _    _    _    _    _    _    _
-  _    _    _    _    _    _    _    _    _    _    _    _    _
-  _    _    _                       _                    _         _
-)
 
-;; ===============================================
-;; SHIFTED SYMBOLS LAYER (Shift-activated on number row)
-;; ===============================================
-
-;; Shifted symbols layer - activated by holding Shift on number row
-(deflayer shifted-symbols
-  _    _    _    _    _    _    _    _    _    _    _    _    _    _
-  _    (multi (release-key lsft) (release-key rsft) AG-1) (multi (release-key lsft) (release-key rsft) AG-2) (multi (release-key lsft) (release-key rsft) AG-3) S-4 (multi (release-key lsft) (release-key rsft) AG-5) (multi (release-key lsft) (release-key rsft) AG-6) (multi (release-key lsft) (release-key rsft) AG-7) (multi (release-key lsft) (release-key rsft) AG-8) (multi (release-key lsft) (release-key rsft) AG-9) (multi (release-key lsft) (release-key rsft) AG-0) _    _    _
-  _    _    _    _    _    _    _    _    _    _    _    _    (multi (release-key lsft) (release-key rsft) AG-¨)  _
-  _    _    _    _    _    _    _    _    _    _    _    _    _
-  _    _    _    _    _    _    _    _    _    _    _    _    _
-  _    _    _                       _                    _         _
-)
 
 ;; ===============================================
 ;; HOME ROW MODS LAYER (Space-activated)
@@ -116,8 +77,8 @@
 ;; Mods layer activated by holding space - outputs QWERTY for all keys
 (deflayer mods-base
   esc  f1   f2   f3   f4   f5   f6   f7   f8   f9   f10  f11  f12  del
-  grv  S-1  S-2  S-3  AG-4  S-5  S-6  S-7  S-8  S-9  S-0  +    ´    bspc
-  _    q    w    e    r    t    y    u    i    o    p    å    S-¨ ret
+  grv  1    2    3    4    5    6    7    8    9    0    +    ´    bspc
+  _    q    w    e    r    t    y    u    i    o    p    å    ¨ ret
   _    @a-met @s-ctl @d-alt @f-sft g    h    @j-sft @k-alt @l-ctl @ö-met ä    '
   lsft <    z    x    c    v    b    n    m    ,    .    -    rsft
   lctl lmet lalt                 _                    ralt        rctl
@@ -130,8 +91,8 @@
 ;; LEFT-ONLY MODS: When left hand mod is pressed, only left hand mods work, right hand uses immediate mods
 (deflayer mods-left-only
   esc  f1   f2   f3   f4   f5   f6   f7   f8   f9   f10  f11  f12  del
-  grv  S-1  S-2  S-3  AG-4  S-5  S-6  S-7  S-8  S-9  S-0  +    ´    bspc
-  _    q    w    e    r    t    y    u    i    o    p    å    S-¨ ret
+  grv  1    2    3    4    5    6    7    8    9    0    +    ´    bspc
+  _    q    w    e    r    t    y    u    i    o    p    å    ¨ ret
   _    @a-met-base @s-ctl-base @d-alt-base @f-sft-base g    h    @j-immediate @k-immediate @l-immediate @ö-immediate ä    '
   lsft <    z    x    c    v    b    n    m    ,    .    -    rsft
   lctl lmet lalt                 _                    ralt        rctl
@@ -140,42 +101,37 @@
 ;; RIGHT-ONLY MODS: When right hand mod is pressed, only right hand mods work, left hand uses immediate mods
 (deflayer mods-right-only
   esc  f1   f2   f3   f4   f5   f6   f7   f8   f9   f10  f11  f12  del
-  grv  S-1  S-2  S-3  AG-4  S-5  S-6  S-7  S-8  S-9  S-0  +    ´    bspc
-  _    q    w    e    r    t    y    u    i    o    p    å    S-¨ ret
+  grv  1    2    3    4    5    6    7    8    9    0    +    ´    bspc
+  _    q    w    e    r    t    y    u    i    o    p    å    ¨ ret
   _    @a-immediate @s-immediate @d-immediate @f-immediate g    h    @j-sft-base @k-alt-base @l-ctl-base @ö-met-base ä    '
   lsft <    z    x    c    v    b    n    m    ,    .    -    rsft
   lctl lmet lalt                 _                    ralt        rctl
 )
 
-;; ===============================================
-;; HYPER LAYER
-;; ===============================================
-
-;; Hyper layer activated by holding Tab
-(deflayer hyper
-  (multi @hyper-mod esc)    _    _    _    _    _    _    _    _    _    _    _    _    _
-  _    (multi @hyper-mod 1)    (multi @hyper-mod 2)    (multi @hyper-mod 3)    (multi @hyper-mod 4)    (multi @hyper-mod 5)    (multi @hyper-mod 6)    (multi @hyper-mod 7)    (multi @hyper-mod 8)    (multi @hyper-mod 9)    (multi @hyper-mod 0)    _    _    _
-  _    (multi @hyper-mod q)    (multi @hyper-mod w)    (multi @hyper-mod e)    (multi @hyper-mod r)    (multi @hyper-mod t)    (multi @hyper-mod y)    (multi @hyper-mod u)    (multi @hyper-mod i)    (multi @hyper-mod o)    (multi @hyper-mod p)    _    _    _
-  _    (multi @hyper-mod a)    (multi @hyper-mod s)    (multi @hyper-mod d)    (multi @hyper-mod f)    (multi @hyper-mod g)    (multi @hyper-mod h)    (multi @hyper-mod j)    (multi @hyper-mod k)    (multi @hyper-mod l)    _    _    _
-  _    _    (multi @hyper-mod z)    (multi @hyper-mod x)    (multi @hyper-mod c)    (multi @hyper-mod v)    (multi @hyper-mod b)    (multi @hyper-mod n)    (multi @hyper-mod m)    _    _    _    _
-  _    _    _                  _                   _    _
-)
 
 ;; ===============================================
 ;; ALIASES
 ;; ===============================================
 
 (defalias
-  ;; Hyper key combination
-  hyper-mod (multi lctl lsft lalt lmet)
 
-  ;; Tab with hyper on hold
-  tab-hyper (tap-hold 50 175 tab (layer-while-held hyper))
+  ;; Tab: tap=tab, double-tap=caps
+  tab-multi (tap-dance 175 (tab caps))
 
-  ;; Multi-function Caps Lock: tap=esc, double-tap=caps, hold=vim-nav
-  caps-multi (tap-dance 175 (
-    (tap-hold-release 50 175 esc (layer-while-held vim-nav))
-    caps
+  ;; Layer switching aliases
+  switch-to-colemak (layer-switch colemak)
+  switch-to-qwerty (layer-switch qwerty)
+  
+  ;; Multi-function Caps Lock for colemak: tap=esc, double-tap=switch-to-qwerty, hold=hyper
+  caps-multi-colemak (tap-dance 175 (
+    (tap-hold-release 50 175 esc (multi lctl lsft lalt lmet))
+    @switch-to-qwerty
+  ))
+  
+  ;; Multi-function Caps Lock for qwerty: tap=esc, double-tap=switch-to-colemak, hold=hyper
+  caps-multi-qwerty (tap-dance 175 (
+    (tap-hold-release 50 175 esc (multi lctl lsft lalt lmet))
+    @switch-to-colemak
   ))
 
   ;; Space with mods layer on hold - with double-tap-and-hold repeat
@@ -194,10 +150,10 @@
   a-met (tap-hold-release 100 180 a (multi lmet (layer-while-held mods-left-only)))
   s-ctl (tap-hold-release 85 150 s (multi lctl (layer-while-held mods-left-only)))
   d-alt (tap-hold-release 85 150 d (multi lalt (layer-while-held mods-left-only)))
-  f-sft (tap-hold-release 75 120 f (multi lsft (layer-while-held mods-left-only) (layer-while-held shifted-symbols)))
+  f-sft (tap-hold-release 75 120 f (multi lsft (layer-while-held mods-left-only)))
 
   ;; Right hand mods that activate right-only restriction
-  j-sft (tap-hold-release 75 120 j (multi rsft (layer-while-held mods-right-only) (layer-while-held shifted-symbols)))
+  j-sft (tap-hold-release 75 120 j (multi rsft (layer-while-held mods-right-only)))
   k-alt (tap-hold-release 85 150 k (multi lalt (layer-while-held mods-right-only)))
   l-ctl (tap-hold-release 85 150 l (multi rctl (layer-while-held mods-right-only)))
   ö-met (tap-hold-release 100 180 ö (multi rmet (layer-while-held mods-right-only)))
@@ -222,9 +178,5 @@
   d-immediate d
   f-immediate f
 
-  ;; Layer-switching modifiers
-  lsft-layer (multi lsft (layer-while-held shifted-symbols))
-  rsft-layer (multi rsft (layer-while-held shifted-symbols))
-  ralt-layer (multi ralt (layer-while-held numbers))
   
 )

--- a/nvim/lua/custom/keyboard_layout_remaps.lua
+++ b/nvim/lua/custom/keyboard_layout_remaps.lua
@@ -1,0 +1,187 @@
+-- Neovim-specific Colemak for insert mode only
+-- Kanata handles Colemak globally, but Neovim can selectively ignore it
+-- Reads layout from /tmp/active_keyboard_layout
+
+-- Colemak to QWERTY mappings (Colemak -> QWERTY)
+-- Since kanata now outputs colemak keys, we need to remap them back to qwerty for navigation
+local colemak_to_qwerty_mappings = {
+	{'f', 'e'}, {'F', 'E'}, {'p', 'r'}, {'P', 'R'}, {'g', 't'}, {'G', 'T'},
+	{'j', 'y'}, {'J', 'Y'}, {'l', 'u'}, {'L', 'U'}, {'u', 'i'}, {'U', 'I'},
+	{'y', 'o'}, {'Y', 'O'}, {'ö', 'p'}, {'Ö', 'P'}, {'r', 's'}, {'R', 'S'},
+	{'s', 'd'}, {'S', 'D'}, {'t', 'f'}, {'T', 'F'}, {'d', 'g'}, {'D', 'G'},
+	{'n', 'j'}, {'N', 'J'}, {'e', 'k'}, {'E', 'K'}, {'i', 'l'}, {'I', 'L'},
+	{'o', 'ö'}, {'O', 'Ö'}, {'k', 'n'}, {'K', 'N'}
+}
+
+-- Apply navigation keymaps (colemak -> qwerty for hjkl movement)
+local function apply_navigation_keymaps()
+	for _, mapping in ipairs(colemak_to_qwerty_mappings) do
+		vim.keymap.set('n', mapping[1], mapping[2], { noremap = true, silent = true })
+	end
+	print("Colemak navigation remapped to QWERTY")
+end
+
+-- Remove navigation keymaps
+local function remove_navigation_keymaps()
+	for _, mapping in ipairs(colemak_to_qwerty_mappings) do
+		pcall(vim.keymap.del, 'n', mapping[1])
+	end
+end
+
+local function setup_keyboard_layout()
+	local layout = "swe" -- Default fallback
+
+	-- Read layout from file
+	local file = io.open("/tmp/active_keyboard_layout", "r")
+	if file then
+		local content = file:read("*a")
+		file:close()
+		if content then
+			layout = content:gsub("%s+", "") -- Remove whitespace
+			-- Remove any non-alphanumeric characters
+			layout = layout:gsub("[^%w_]", "")
+		end
+	end
+	
+	-- Normalize layer names - treat plain variants as equivalent to their base layers
+	if layout == "colemak_plain" then
+		layout = "cmk"
+	elseif layout == "nordic_plain" then
+		layout = "swe"
+	end
+
+	if layout == "cmk" then
+		-- When Kanata is in Colemak mode, remap navigation keys to QWERTY positions
+		-- This allows hjkl movement to work correctly when kanata outputs colemak keys
+		
+		-- Remove any existing navigation keymaps first
+		remove_navigation_keymaps()
+		
+		-- Apply colemak->qwerty navigation keymaps
+		apply_navigation_keymaps()
+
+		-- Store that we want Colemak mode
+		vim.g.colemak_mode = true
+
+		print("Neovim: Colemak with QWERTY navigation remapped")
+	elseif layout == "swe" then
+		-- Swedish QWERTY - remove any colemak navigation remaps
+		remove_navigation_keymaps()
+		
+		-- Store that we want Swedish mode
+		vim.g.colemak_mode = false
+
+	else
+		-- Only print error for truly unknown layouts (not empty)
+		if layout ~= "" then
+			-- Debug: show exact content and byte values
+			local bytes = {}
+			for i = 1, #layout do
+				table.insert(bytes, string.byte(layout, i))
+			end
+			local msg = "Unknown keyboard layout: '" .. layout .. "' (length=" .. #layout .. ", bytes={" .. table.concat(bytes, ",") .. "}). Using QWERTY."
+			print(msg)
+			-- Also log to file for debugging
+			local log = io.open("/tmp/nvim_keyboard_debug.log", "a")
+			if log then
+				log:write(os.date("%Y-%m-%d %H:%M:%S") .. " - " .. msg .. "\n")
+				log:close()
+			end
+		end
+		remove_navigation_keymaps()
+		vim.g.colemak_mode = false
+	end
+
+	vim.g.detected_keyboard_layout = layout
+end
+
+-- Initialize on startup
+setup_keyboard_layout()
+
+-- Set up file watcher for automatic reloading
+local layout_file = "/tmp/active_keyboard_layout"
+local watcher = nil
+
+local function start_file_watcher()
+	if watcher then
+		watcher:stop()
+	end
+
+	watcher = vim.loop.new_fs_event()
+	if watcher then
+		watcher:start(
+			layout_file,
+			{},
+			vim.schedule_wrap(function(err, filename, events)
+				if err then
+					print("Keyboard layout file watcher error: " .. err)
+					return
+				end
+
+				if events.change then
+					local old_colemak_mode = vim.g.colemak_mode
+					setup_keyboard_layout()
+					local new_colemak_mode = vim.g.colemak_mode
+
+					-- Only print if the functional mode actually changed
+					if old_colemak_mode ~= new_colemak_mode then
+						if new_colemak_mode then
+							print("Switched to Colemak with QWERTY navigation")
+						else
+							print("Switched to Swedish QWERTY layout")
+						end
+					end
+				end
+			end)
+		)
+	end
+end
+
+-- Start watching
+local file = io.open(layout_file, "r")
+if file then
+	file:close()
+	start_file_watcher()
+else
+	file = io.open(layout_file, "w")
+	if file then
+		file:write("swe")
+		file:close()
+		start_file_watcher()
+	end
+end
+
+-- Clean up watcher on exit
+vim.api.nvim_create_autocmd("VimLeavePre", {
+	callback = function()
+		if watcher then
+			watcher:stop()
+		end
+	end,
+})
+
+-- Manual reload command
+vim.api.nvim_create_user_command("ReloadKeyboardLayout", function()
+	setup_keyboard_layout()
+end, { desc = "Reload keyboard layout from /tmp/active_keyboard_layout" })
+
+
+-- No need for insert mode autocmds since we're now handling navigation keys in normal mode only
+
+-- Test command
+vim.api.nvim_create_user_command("TestColemakLayout", function()
+	local layout = vim.g.detected_keyboard_layout or "unknown"
+	print("Current layout: " .. layout)
+	print("Colemak mode: " .. tostring(vim.g.colemak_mode))
+
+	if layout == "cmk" then
+		print("✓ COLEMAK WITH QWERTY NAVIGATION ACTIVE")
+		print("Kanata outputs: Colemak keys")
+		print("Neovim navigation: hjkl remapped to work with colemak (h->h, n->j, e->k, i->l)")
+		print("Keybinds: All vim bindings work correctly")
+		print("Hyprland: Uses passthrough layer for Super+key combinations")
+	elseif layout == "swe" then
+		print("✓ SWEDISH QWERTY ACTIVE")
+		print("Everything uses standard QWERTY positions")
+	end
+end, { desc = "Test current Colemak setup" })

--- a/nvim/lua/custom/keymaps.lua
+++ b/nvim/lua/custom/keymaps.lua
@@ -293,10 +293,10 @@ local basic_mappings = {
 
 -- Faster navigation
 local fastnav_mappings = {
-	{ "n", "<C-down>", "10j", { desc = "Move down 10 times" } },
-	{ "v", "<C-down>", "10j", { desc = "Move down 10 times" } },
-	{ "n", "<C-up>", "10k", { desc = "Move up 10 times" } },
-	{ "v", "<C-up>", "10k", { desc = "Move up 10 times" } },
+	{ "n", "<C-j>", "10j", { desc = "Move down 10 times" } },
+	{ "v", "<C-j>", "10j", { desc = "Move down 10 times" } },
+	{ "n", "<C-k>", "10k", { desc = "Move up 10 times" } },
+	{ "v", "<C-k>", "10k", { desc = "Move up 10 times" } },
 }
 
 -- Fast edit mappings

--- a/scripts/kanata/kanata_tools/kanata_tools/cli.py
+++ b/scripts/kanata/kanata_tools/kanata_tools/cli.py
@@ -38,7 +38,7 @@ def main():
     init_parser.add_argument(
         "--fresh-start",
         action="store_true",
-        help="Force default state (Colemak) ignoring saved state"
+        help="Force default state (QWERTY) ignoring saved state"
     )
     
     # Listen command
@@ -72,8 +72,8 @@ def main():
     elif args.command == "init":
         switcher = KanataLayerSwitcher()
         if args.fresh_start:
-            # Force default state (Colemak)
-            if not switcher.set_specific_layer("cmk", "base"):
+            # Force default state (QWERTY)
+            if not switcher.set_specific_layer("qwe", "base"):
                 sys.exit(1)
         else:
             # Smart init based on reboot detection

--- a/scripts/kanata/kanata_tools/kanata_tools/config.py
+++ b/scripts/kanata/kanata_tools/kanata_tools/config.py
@@ -54,8 +54,8 @@ STATUS_CONFIG = {
     },
 }
 
-# Default state after reboot (Colemak as default)
+# Default state after reboot (QWERTY as default)
 DEFAULT_STATE = {
-    "layout": "cmk",
+    "layout": "qwe",
     "mod_state": "base"
 }

--- a/scripts/kanata/kanata_tools/kanata_tools/status_listener.py
+++ b/scripts/kanata/kanata_tools/kanata_tools/status_listener.py
@@ -24,8 +24,8 @@ class KanataStatusListener:
     
     def __init__(self):
         self.setup_logging()
-        self.current_layout = "swe"
-        self.current_mod_state = "mod"
+        self.current_layout = "qwe"
+        self.current_mod_state = "base"
         self.state_manager = StateManager(self.logger)
     
     def setup_logging(self):

--- a/systemd/user/kanata-status-listener.service
+++ b/systemd/user/kanata-status-listener.service
@@ -6,7 +6,7 @@ Wants=graphical-session.target
 
 [Service]
 Type=simple
-ExecStart=kanata-tools listen
+ExecStart=/home/rash/.local/bin/kanata-tools listen
 Restart=always
 RestartSec=5
 StandardOutput=journal
@@ -23,8 +23,8 @@ ProtectHome=read-only
 ReadWritePaths=/tmp
 PrivateTmp=no
 
-# Allow access to /tmp for status files
-ReadWritePaths=/tmp
+# Allow access to /tmp for status files and kanata config for persistent state
+ReadWritePaths=/tmp /home/rash/.config/kanata
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Keep just a basic switch layout that cycles between qwerty and colemak.
- Remove number row mods
- Tab: tap - tab, double - capslock
- Caps: tap - esc, double - layout switch, hold - hyper
- Space: tap - space, hold - homerowmods

Notes:
- Same hand restriction for home row mods (only can be combined with other home row mods in the same hand and not in opposting hands)
- Activating home row mods also switches the non-mod keys to qwety momentarily

Commits:
- **Simpler kanata init**
- **Revert nvim mappings**
